### PR TITLE
convert to int in sql

### DIFF
--- a/backend/internal/data/shutter_explorer.sql.go
+++ b/backend/internal/data/shutter_explorer.sql.go
@@ -503,7 +503,7 @@ SELECT
 FROM decrypted_tx
 WHERE tx_status = $1
 GROUP BY DATE_TRUNC('month', created_at)
-ORDER BY month
+ORDER BY month DESC
 `
 
 type QueryTotalTXsForEachTXStatusPerMonthRow struct {

--- a/backend/internal/data/sql/queries/shutter_explorer.sql
+++ b/backend/internal/data/sql/queries/shutter_explorer.sql
@@ -22,7 +22,7 @@ SELECT
 FROM decrypted_tx
 WHERE tx_status = $1
 GROUP BY DATE_TRUNC('month', created_at)
-ORDER BY month;
+ORDER BY month DESC;
 
 -- name: QueryLatestPendingTXsWhichCanBeDecrypted :many
 WITH latest_per_hash AS (

--- a/backend/internal/data/sql/queries/shutter_explorer.sql
+++ b/backend/internal/data/sql/queries/shutter_explorer.sql
@@ -152,7 +152,8 @@ LIMIT 1;
 -- name: QueryTransactionDetailsByTxHash :one
 SELECT 
     tse.event_tx_hash, tse.sender, FLOOR(EXTRACT(EPOCH FROM tse.created_at)) as created_at_unix,
-    dt.tx_hash AS user_tx_hash, dt.tx_status, dt.slot, FLOOR(EXTRACT(EPOCH FROM dt.created_at)) AS decrypted_tx_created_at_unix
+    dt.tx_hash AS user_tx_hash, dt.tx_status, dt.slot, 
+    COALESCE(FLOOR(EXTRACT(EPOCH FROM dt.created_at)), 0)::BIGINT AS decrypted_tx_created_at_unix
 FROM transaction_submitted_event tse 
 LEFT JOIN decrypted_tx dt ON tse.id = dt.transaction_submitted_event_id
 WHERE tse.event_tx_hash = $1 OR dt.tx_hash = $1

--- a/backend/internal/service/transaction.go
+++ b/backend/internal/service/transaction.go
@@ -146,3 +146,14 @@ func (svc *TransactionService) QueryLatestSequencerTransactions(ctx *gin.Context
 		"message": txs,
 	})
 }
+
+func (svc *TransactionService) QueryTransactionPercentage(ctx *gin.Context) {
+	transactionPercentage, err := svc.TransactionUsecase.QueryTransactionPercentage(ctx, "included")
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{
+		"message": transactionPercentage,
+	})
+}

--- a/backend/internal/usecase/transaction.go
+++ b/backend/internal/usecase/transaction.go
@@ -212,7 +212,7 @@ func (uc *TransactionUsecase) QueryTransactionDetailsByTxHash(ctx context.Contex
 	if tse.TxStatus.Valid {
 		if tse.TxStatus.TxStatusVal == data.TxStatusValIncluded {
 			txStatus = Completed
-			effectiveInclusionTime = int64(tse.DecryptedTxCreatedAtUnix)
+			effectiveInclusionTime = tse.DecryptedTxCreatedAtUnix
 			if tse.Slot.Valid {
 				inclusionSlot = tse.Slot.Int64
 			}
@@ -273,7 +273,7 @@ func (uc *TransactionUsecase) QueryTransactionDetailsByTxHash(ctx context.Contex
 		TxStatus:               string(txStatus),
 		InclusionSlot:          inclusionSlot,
 		SequencerTxSubmittedAt: int64(tse.CreatedAtUnix),
-		DecryptedTxCreatedAt:   int64(tse.DecryptedTxCreatedAtUnix),
+		DecryptedTxCreatedAt:   tse.DecryptedTxCreatedAtUnix,
 		EffectiveInclusionTime: effectiveInclusionTime,
 		EstimatedInclusionTime: estimatedInclusionTime,
 	}

--- a/backend/router/router.go
+++ b/backend/router/router.go
@@ -36,6 +36,7 @@ func NewRouter(ctx context.Context, usecases *usecase.Usecases) *gin.Engine {
 		transaction.GET("/total_transactions_per_month", transactionService.QueryTotalExecutedTXsForEachTXStatusPerMonth)
 		transaction.GET("/:hash", transactionService.QueryTransactionDetailsByTxHash)
 		transaction.GET("/latest_sequencer_transactions", transactionService.QueryLatestSequencerTransactions)
+		transaction.GET("/transaction_percentage", transactionService.QueryTransactionPercentage)
 	}
 	{
 		validator := api.Group("/validator")


### PR DESCRIPTION
1. The main issue was how sqlc generated the related go bindings for the sql query. We are now directly converting the numeric column to `BIGINT` sql type in the sql query as a fix.
2. Also adds endpoint for transaction_percentage

Closes #73