### PR TITLE
feat: navigation issue fix

### DIFF
--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
- This issue originated because netlify does not have information about react redirect rules and considers only `index.html`, generated after build, as the file to be rendered.
- As solution to this, I added a netlify config file which redirects all requests to the react app. This lets react app to handle all redirects and load the specific page requested directly